### PR TITLE
Excluded control characters from allowed delimiters

### DIFF
--- a/src/defs.rs
+++ b/src/defs.rs
@@ -3,9 +3,6 @@
 /// Whitespace character.
 pub const WS: char = ' ';
 
-/// Horizontal tab character.
-pub const TAB: char = '\t';
-
 /// Line feed character.
 pub const LF: char = '\n';
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -310,7 +310,7 @@ impl<'a> Tokenizer<'a> {
 
   /// Returns `true` when the specified character is allowed delimiter character.
   fn is_allowed_delimiter(&self, ch: char) -> bool {
-    !(self.is_node_name_char(ch) || matches!(ch, NULL | WS | TAB | LF | CR | UNDERSCORE | HYPHEN))
+    !(self.is_node_name_char(ch) || matches!(ch, NULL..=WS | UNDERSCORE | HYPHEN))
   }
 
   /// Returns `true` when the specified character is recognized delimiter.


### PR DESCRIPTION
Excluded control characters (0x00..0x19) from valid delimiters.