### PR TITLE
Removed unnecessary restrictions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "idml"
-version = "0.4.3"
+version = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idml"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Dariusz Depta <depta@engos.de>"]
 description = "Parser for Indented Delimiter Markup Language"
 documentation = "https://docs.rs/idml"

--- a/src/defs.rs
+++ b/src/defs.rs
@@ -3,17 +3,14 @@
 /// Whitespace character.
 pub const WS: char = ' ';
 
+/// Horizontal tabulator character.
+pub const TAB: char = '\t';
+
 /// Line feed character.
 pub const LF: char = '\n';
 
 /// Carriage return character.
 pub const CR: char = '\r';
-
-/// Hyphen character.
-pub const HYPHEN: char = '-';
-
-/// Underscore character.
-pub const UNDERSCORE: char = '_';
 
 /// Empty character (zero).
 pub const NULL: char = 0 as char;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,3 +58,8 @@ pub fn err_expected_indentation() -> IdmlError {
 pub fn err_malformed_indentation(indent: usize, multiplier: usize) -> IdmlError {
   IdmlError::new(&format!("malformed indentation {indent}, expected multiplication of {multiplier}"))
 }
+
+/// Reports inconsistent indentation.
+pub fn err_inconsistent_indentation() -> IdmlError {
+  IdmlError::new("inconsistent indentation, mixed spaces and tabs")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod node;
 mod parser;
 mod tokenizer;
 
+pub use defs::{CR, LF, NULL, TAB, WS};
 pub use node::Node;
-pub use parser::{Parser, parse};
-pub use tokenizer::{Token, Tokenizer, tokenize};
+pub use parser::{parse, Parser};
+pub use tokenizer::{tokenize, Token, Tokenizer};

--- a/src/node.rs
+++ b/src/node.rs
@@ -130,14 +130,18 @@ impl Node {
   }
 
   /// Returns a document starting from this node.
-  pub fn document(&self, indent: usize) -> String {
+  pub fn document(&self, indent: usize, ch: char) -> String {
     let mut buffer = String::new();
     if !self.is_root() {
-      let indentation = if self.level > 1 { " ".repeat((self.level - 1) * indent) } else { "".to_string() };
+      let indentation = if self.level > 1 {
+        ch.to_string().repeat((self.level - 1) * indent)
+      } else {
+        "".to_string()
+      };
       let _ = write!(&mut buffer, "{}{}{}{}", indentation, self.delimiter, self.name, self.content);
     }
     for child in &self.children {
-      let _ = write!(&mut buffer, "{}", child.document(indent));
+      let _ = write!(&mut buffer, "{}", child.document(indent, ch));
     }
     buffer
   }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -138,7 +138,7 @@ impl<'a> Tokenizer<'a> {
           // Process the beginning of the document.
           match self.context() {
             (_, NULL, _) => return Err(err_empty_input()),
-            (_, ch, _) if self.is_allowed_delimiter(ch) => {
+            (_, ch, _) if self.is_allowed_char(ch) => {
               self.delimiter = ch;
               self.tokens.push(Token::Indentation(0, NULL));
               self.state = TokenizerState::NodeName;
@@ -200,7 +200,7 @@ impl<'a> Tokenizer<'a> {
               self.node_content.push_str(self.line_ending.as_ref());
               self.state = TokenizerState::NewLine;
             }
-            (_, ch, _) if self.is_node_name_char(ch) => {
+            (_, ch, _) if self.is_allowed_char(ch) => {
               self.node_name.push(self.current_char);
             }
             (_, other, _) => {
@@ -290,19 +290,14 @@ impl<'a> Tokenizer<'a> {
     self.node_content.clear();
   }
 
-  /// Returns `true` when the specified character is allowed delimiter character.
-  fn is_allowed_delimiter(&self, ch: char) -> bool {
+  /// Returns `true` when the specified character is allowed character.
+  fn is_allowed_char(&self, ch: char) -> bool {
     matches!(ch, '\u{0021}'..='\u{10FFFF}')
   }
 
   /// Returns `true` when the specified character is equal to recognized delimiter.
   fn is_delimiter(&self, ch: char) -> bool {
     ch == self.delimiter
-  }
-
-  /// Returns `true` when the specified character is a node name character.
-  fn is_node_name_char(&self, ch: char) -> bool {
-    matches!(ch, '\u{0021}'..='\u{10FFFF}')
   }
 
   /// Advances the counter to the next row.

--- a/tests/invalid_input.rs
+++ b/tests/invalid_input.rs
@@ -1,4 +1,4 @@
-use idml::{parse, Parser, Token};
+use idml::{parse, Parser, Token, WS};
 
 #[test]
 fn _0001() {
@@ -23,91 +23,70 @@ fn _0003() {
 
 #[test]
 fn _0004() {
-  // No node name, only delimiter present.
+  // Only delimiter present.
   let input = ".";
   assert_eq!("unexpected end of input", parse(input).unwrap_err().to_string());
 }
 
 #[test]
 fn _0005() {
-  // No node name, space after delimiter.
+  // No newline after empty name.
   let input = ". ";
-  assert_eq!("unexpected character: ' ' 0x20 at row 1 and column 2", parse(input).unwrap_err().to_string());
+  assert_eq!("unexpected end of input", parse(input).unwrap_err().to_string());
 }
 
 #[test]
 fn _0006() {
-  // No node name, line feed after delimiter.
-  let input = ".\n";
-  assert_eq!("unexpected character: '\n' 0x0A at row 1 and column 2", parse(input).unwrap_err().to_string());
+  for ch in '\u{0001}'..='\u{0020}' {
+    println!("{}", ch as u8);
+    let input = format!("{}", ch);
+    let expected = format!("unexpected character: '{}' 0x{:02X} at row 1 and column 1", ch, ch as u8);
+    assert_eq!(expected, parse(&input).unwrap_err().to_string());
+  }
+  assert_eq!("unexpected character: '\r' 0x0D at row 1 and column 1", parse("\r\n").unwrap_err().to_string());
 }
 
 #[test]
 fn _0007() {
-  // No node name, carriage return after delimiter.
-  let input = ".\r";
-  assert_eq!("unexpected character: '\r' 0x0D at row 1 and column 2", parse(input).unwrap_err().to_string());
+  for ch in '\u{0001}'..='\u{0019}' {
+    if !matches!(ch, '\n' | '\r' | '\t') {
+      let input = format!(".{}", ch);
+      let expected = format!("unexpected character: '{}' 0x{:02X} at row 1 and column 2", ch, ch as u8);
+      assert_eq!(expected, parse(&input).unwrap_err().to_string());
+    }
+  }
 }
 
 #[test]
 fn _0008() {
-  // No node name, carriage return and line feed after delimiter.
-  let input = ".\r\n";
-  assert_eq!("unexpected character: '\r' 0x0D at row 1 and column 2", parse(input).unwrap_err().to_string());
-}
-
-#[test]
-fn _0009() {
   // Node name is not followed by a whitespace, newline or both.
   let input = ".A";
   assert_eq!("unexpected end of input", parse(input).unwrap_err().to_string());
 }
 
 #[test]
-fn _0010() {
+fn _0009() {
   // Node name is not followed by a whitespace and newline.
   let input = ".A ";
   assert_eq!("unexpected end of input", parse(input).unwrap_err().to_string());
 }
 
 #[test]
-fn _0011() {
-  // Root node name must be at the very beginning of the line, without any indentation.
+fn _0010() {
+  // Root node name must be at the very beginning of the line, without any indentation before like space.
   let input = " .A\n";
   assert_eq!("unexpected character: ' ' 0x20 at row 1 and column 1", parse(input).unwrap_err().to_string());
 }
 
 #[test]
+fn _0011() {
+  // Root node name must be at the very beginning of the line, without any indentation before like horizontal tab.
+  let input = "\t.A\n";
+  assert_eq!("unexpected character: '\t' 0x09 at row 1 and column 1", parse(input).unwrap_err().to_string());
+}
+
+#[test]
 fn _0012() {
-  // Root node name must be at the very beginning of the line,
-  // without any additional characters before it.
-  let input = "n.A\n";
-  assert_eq!("unexpected character: 'n' 0x6E at row 1 and column 1", parse(input).unwrap_err().to_string());
-}
-
-#[test]
-fn _0013() {
-  // Node name must start with a single dot.
-  let input = "..A\n";
-  assert_eq!("unexpected character: '.' 0x2E at row 1 and column 2", parse(input).unwrap_err().to_string());
-}
-
-#[test]
-fn _0014() {
-  // Node name must end with whitespace or newline or whitespace and newline.
-  let input = ".A!\n";
-  assert_eq!("unexpected character: '!' 0x21 at row 1 and column 3", parse(input).unwrap_err().to_string());
-}
-
-#[test]
-fn _0015() {
-  // After delimiter there must be a node name start.
-  let input = ".A\n   .!\n";
-  assert_eq!("unexpected character: '!' 0x21 at row 2 and column 5", parse(input).unwrap_err().to_string());
-}
-
-#[test]
-fn _0016() {
   // Spaces after the last newline character.
   let input = r#".MODEL
     .NAMESPACE https://decision-toolkit.org/2_0001/
@@ -116,7 +95,7 @@ fn _0016() {
 }
 
 #[test]
-fn _0017() {
+fn _0013() {
   // Malformed indentation
   let input = r#".A
     .B
@@ -127,7 +106,7 @@ fn _0017() {
 }
 
 #[test]
-fn _0018() {
+fn _0014() {
   // Malformed indentation
   let input = r#".A
         .B
@@ -138,22 +117,36 @@ fn _0018() {
 }
 
 #[test]
-fn _0019() {
+fn _0015() {
+  // Inconsistent indentation
+  let input = ".A\n  .B\n\t\t.C\n  .D\n";
+  assert_eq!("inconsistent indentation, mixed spaces and tabs", parse(input).unwrap_err().to_string());
+}
+
+#[test]
+fn _0016() {
+  // Inconsistent indentation
+  let input = ".A\n  .B\n \t.C\n  .D\n";
+  assert_eq!("inconsistent indentation, mixed spaces and tabs", parse(input).unwrap_err().to_string());
+}
+
+#[test]
+fn _0017() {
   // No indentation token.
   let tokens = vec![Token::NodeName("A".to_string(), '.')];
   assert_eq!("expected indentation token", Parser::new(tokens).parse().unwrap_err().to_string())
 }
 
 #[test]
-fn _0020() {
+fn _0018() {
   // No node name token.
-  let tokens = vec![Token::Indentation(0), Token::NodeContent("content".to_string())];
+  let tokens = vec![Token::Indentation(0, WS), Token::NodeContent("content".to_string())];
   assert_eq!("expected node name token", Parser::new(tokens).parse().unwrap_err().to_string())
 }
 
 #[test]
-fn _0021() {
+fn _0019() {
   // No node content token.
-  let tokens = vec![Token::Indentation(0), Token::NodeName("name".to_string(), '.'), Token::Indentation(0)];
+  let tokens = vec![Token::Indentation(0, WS), Token::NodeName("name".to_string(), '.'), Token::Indentation(0, WS)];
   assert_eq!("expected node content token", Parser::new(tokens).parse().unwrap_err().to_string())
 }

--- a/tests/valid_input.rs
+++ b/tests/valid_input.rs
@@ -1,7 +1,105 @@
-use idml::parse;
+use idml::{parse, TAB, WS};
 
 #[test]
 fn _0001() {
+  let inputs = ["-\n", "-\r", "-\r\n", "- \n"];
+  for input in inputs {
+    let root = parse(input).unwrap();
+    assert_eq!(1, root.children().count());
+    let node = root.children().next().unwrap();
+    assert_eq!('-', node.delimiter());
+    assert_eq!("", node.name());
+    assert_eq!(&input[1..], node.content());
+    assert_eq!("", node.text());
+  }
+}
+
+#[test]
+fn _0002() {
+  let input = "- node content\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('-', node.delimiter());
+  assert_eq!("", node.name());
+  assert_eq!(" node content\n", node.content());
+  assert_eq!("node content", node.text());
+}
+
+#[test]
+fn _0003() {
+  let input = "ab\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("b", node.name());
+  assert_eq!("\n", node.content());
+  assert_eq!("", node.text());
+}
+
+#[test]
+fn _0004() {
+  let input = "aa b\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("a", node.name());
+  assert_eq!(" b\n", node.content());
+  assert_eq!("b", node.text());
+}
+
+#[test]
+fn _0005() {
+  let input = "aa\nb\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("a", node.name());
+  assert_eq!("\nb\n", node.content());
+  assert_eq!("b", node.text());
+}
+
+#[test]
+fn _0006() {
+  let input = "aa\rb\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("a", node.name());
+  assert_eq!("\rb\n", node.content());
+  assert_eq!("b", node.text());
+}
+
+#[test]
+fn _0007() {
+  let input = "aa\r\nb\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("a", node.name());
+  assert_eq!("\r\nb\n", node.content());
+  assert_eq!("b", node.text());
+}
+
+#[test]
+fn _0008() {
+  let input = "aa\tb\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('a', node.delimiter());
+  assert_eq!("a", node.name());
+  assert_eq!("\tb\n", node.content());
+  assert_eq!("b", node.text());
+}
+
+#[test]
+fn _0009() {
   let input = ".A\n";
   let root = parse(input).unwrap();
   assert_eq!(1, root.children().count());
@@ -13,19 +111,19 @@ fn _0001() {
 }
 
 #[test]
-fn _0002() {
-  let input = "😀_this_is-some_casing-tag\n";
+fn _0010() {
+  let input = "😀_this_is-some_funny-name\n";
   let root = parse(input).unwrap();
   assert_eq!(1, root.children().count());
   let node = root.children().next().unwrap();
   assert_eq!('😀', node.delimiter());
-  assert_eq!("_this_is-some_casing-tag", node.name());
+  assert_eq!("_this_is-some_funny-name", node.name());
   assert_eq!("\n", node.content());
   assert_eq!("", node.text());
 }
 
 #[test]
-fn _0003() {
+fn _0011() {
   let input = ">z\n";
   let root = parse(input).unwrap();
   assert_eq!(1, root.children().count());
@@ -37,7 +135,7 @@ fn _0003() {
 }
 
 #[test]
-fn _0004() {
+fn _0012() {
   let input = ".A1\n";
   let root = parse(input).unwrap();
   assert_eq!(1, root.children().count());
@@ -49,7 +147,7 @@ fn _0004() {
 }
 
 #[test]
-fn _0005() {
+fn _0013() {
   let input = ".A\n.k\n";
   let root = parse(input).unwrap();
   let mut children = root.children();
@@ -67,7 +165,7 @@ fn _0005() {
 }
 
 #[test]
-fn _0006() {
+fn _0014() {
   let input = "$x\n$_\n";
   let root = parse(input).unwrap();
   let mut children = root.children();
@@ -85,7 +183,7 @@ fn _0006() {
 }
 
 #[test]
-fn _0007() {
+fn _0015() {
   let input = "*n\n    *_\n";
   let root = parse(input).unwrap();
   let mut children = root.children();
@@ -103,7 +201,7 @@ fn _0007() {
 }
 
 #[test]
-fn _0008() {
+fn _0016() {
   let input = ".A\n$B\n";
   let root = parse(input).unwrap();
   let mut children = root.children();
@@ -116,43 +214,31 @@ fn _0008() {
 }
 
 #[test]
-fn _0009() {
+fn _0017() {
   let input = ".A\r";
   let root = parse(input).unwrap();
-  assert_eq!(input, root.document(4));
+  assert_eq!(input, root.document(4, WS));
 }
 
 #[test]
-fn _0010() {
+fn _0018() {
   let input = ".A\r\n";
   let root = parse(input).unwrap();
-  assert_eq!(input, root.document(4));
+  assert_eq!(input, root.document(4, WS));
 }
 
 #[test]
-fn _0011() {
+fn _0019() {
   let input = r#".A
     .B
     .C
 "#;
   let root = parse(input).unwrap();
-  assert_eq!(input, root.document(4));
+  assert_eq!(input, root.document(4, WS));
 }
 
 #[test]
-fn _0012() {
-  let input = r#".A
-
-
-    .B
-    .C
-"#;
-  let root = parse(input).unwrap();
-  assert_eq!(input, root.document(4));
-}
-
-#[test]
-fn _0013() {
+fn _0020() {
   let input = r#".A
 
   some content
@@ -161,5 +247,19 @@ fn _0013() {
     .C
 "#;
   let root = parse(input).unwrap();
-  assert_eq!(input, root.document(4));
+  assert_eq!(input, root.document(4, WS));
+}
+
+#[test]
+fn _0021() {
+  let input = ".A\n\t.B\n\t.C\n";
+  let root = parse(input).unwrap();
+  assert_eq!(input, root.document(1, TAB));
+}
+
+#[test]
+fn _0022() {
+  let input = ".A\n\t\t.B\n\t\t.C\n";
+  let root = parse(input).unwrap();
+  assert_eq!(input, root.document(2, TAB));
 }

--- a/tests/valid_input.rs
+++ b/tests/valid_input.rs
@@ -263,3 +263,15 @@ fn _0022() {
   let root = parse(input).unwrap();
   assert_eq!(input, root.document(2, TAB));
 }
+
+#[test]
+fn _0023() {
+  let input = ".node name node content\n";
+  let root = parse(input).unwrap();
+  assert_eq!(1, root.children().count());
+  let node = root.children().next().unwrap();
+  assert_eq!('.', node.delimiter());
+  assert_eq!("node name", node.name());
+  assert_eq!(" node content\n", node.content());
+  assert_eq!("node content", node.text());
+}


### PR DESCRIPTION
Removed restrictions on delimiter, now delimiter can be any Unicode character in range [`U+0021`..`U+10FFFF`].
Removed restrictions on node name, now node name can be any Unicode character in range [`U+0021`..`U+10FFFF`].
Enabled tabs (`U+09`) as indentation.